### PR TITLE
PR: CartItem 클래스 생성자 누락 오류 수정

### DIFF
--- a/src/main/java/com/fastbank/be/domain/CartItem.java
+++ b/src/main/java/com/fastbank/be/domain/CartItem.java
@@ -41,5 +41,9 @@ public class CartItem {
     }
 
     public CartItem(String memberEmail, Long id, String name, String type) {
+        this.email = memberEmail;
+        this.id = id;
+        this.name = name;
+        this.type = type;
     }
 }


### PR DESCRIPTION
- CartItem의 생성자 메서드에 아무런 코드가 없는 오류가 있어 데이터베이스에 데이터가 전달되지 않는 오류가 있었음.
- CartItem의 생성자 코드를 수정하였음.