### PR TITLE
PR: CartItem 중복 추가 에러 수정

### DIFF
--- a/src/main/java/com/fastbank/be/persistence/CartItemRepository.java
+++ b/src/main/java/com/fastbank/be/persistence/CartItemRepository.java
@@ -5,10 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
     List<CartItem> findAllByEmail(String authorization);
 
     @Transactional
     void deleteByIdAndEmail(Long productIds, String memberEmail);
+
+    Optional<CartItem> findByIdAndEmail(Long productId, String memberEmail);
 }

--- a/src/main/java/com/fastbank/be/web/controller/CartController.java
+++ b/src/main/java/com/fastbank/be/web/controller/CartController.java
@@ -50,6 +50,9 @@ public class CartController {
         List<CartItem> newlyAddedItems = new ArrayList<>();
 
         for (Long productId : productIds) {
+            if (cartItemRepository.findByIdAndEmail(productId, memberEmail).isPresent()) {
+                continue;
+            }
             Optional<Product> result = productRepository.findById(productId);
             Product product = result.orElseThrow(NoSuchElementException::new);
             newlyAddedItems.add(new CartItem(memberEmail, product.getId(), product.getName(), product.getType()));


### PR DESCRIPTION
- 클라이언트에서 이미 회원의 장바구니에 들어 있는 제품(product)을 다시 추가하는 요청이 왔을 때, 장바구니에 동일한 상품이 그대로 추가되는 오류가 발생함.
- 수정 후: 클라이언트가 이미 회원의 장바구니에 들어 있는 제품을 추가해 달라는 요청을 줄 경우, 서버에서는 이를 무시하고 추가하지 않도록 수정함.